### PR TITLE
Add audio reactive drawing features

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
 import { Download, Shuffle, Play, Pause, Film, Loader2 } from "lucide-react"
 import { useGifJs } from "@/components/gif-recorder"
+import useAudioInput from "@/hooks/use-audio-input"
 
 /* ---------- Types & Constants ---------- */
 
@@ -22,6 +23,7 @@ interface ArtParameters {
   opacity: number
   complexity: number
   isAnimated: boolean
+  audioReactive: boolean
   // Fractal specific parameters
   fractalType: string
   fractalIterations: number
@@ -58,11 +60,14 @@ export default function AlgorithmicArtGenerator() {
     opacity: 0.7,
     complexity: 3,
     isAnimated: true,
+    audioReactive: false,
     fractalType: "mandala",
     fractalIterations: 100,
     fractalScale: 0.5,
     fractalAngle: 0.5,
   })
+
+  const audioData = useAudioInput(parameters.audioReactive)
 
   const updateParameter = (key: keyof ArtParameters, value: any) => setParameters((prev) => ({ ...prev, [key]: value }))
 
@@ -70,35 +75,41 @@ export default function AlgorithmicArtGenerator() {
 
   const drawCirclePattern = useCallback(
     (ctx: CanvasRenderingContext2D, time: number) => {
+      const { volume, frequency } = audioData
       const { shapeCount, shapeSize, animationSpeed, rotationSpeed, opacity, complexity } = parameters
       const colors = colorPalettes[parameters.colorPalette as PaletteKey]
+      const volumeFactor = 1 + volume
+      const colorOffset = Math.floor(frequency * colors.length)
       const { width, height } = ctx.canvas
 
       for (let i = 0; i < shapeCount; i++) {
         const angle = (i / shapeCount) * Math.PI * 2 * complexity + time * animationSpeed * 0.01
-        const radius = Math.min(width, height) * 0.3
+        const radius = Math.min(width, height) * 0.3 * volumeFactor
         const x = width / 2 + Math.cos(angle) * radius * (0.5 + Math.sin(time * rotationSpeed * 0.005 + i) * 0.3)
         const y = height / 2 + Math.sin(angle) * radius * (0.5 + Math.cos(time * rotationSpeed * 0.005 + i) * 0.3)
 
         ctx.globalAlpha = opacity
-        ctx.fillStyle = colors[i % colors.length]
+        ctx.fillStyle = colors[(i + colorOffset) % colors.length]
         ctx.beginPath()
-        ctx.arc(x, y, shapeSize * (0.5 + Math.sin(time * 0.01 + i) * 0.5), 0, Math.PI * 2)
+        ctx.arc(x, y, shapeSize * (0.5 + Math.sin(time * 0.01 + i) * 0.5) * volumeFactor, 0, Math.PI * 2)
         ctx.fill()
       }
     },
-    [parameters],
+    [parameters, audioData],
   )
 
   const drawTrianglePattern = useCallback(
     (ctx: CanvasRenderingContext2D, time: number) => {
+      const { volume, frequency } = audioData
       const { shapeCount, shapeSize, animationSpeed, rotationSpeed, opacity, complexity } = parameters
       const colors = colorPalettes[parameters.colorPalette as PaletteKey]
+      const volumeFactor = 1 + volume
+      const colorOffset = Math.floor(frequency * colors.length)
       const { width, height } = ctx.canvas
 
       for (let i = 0; i < shapeCount; i++) {
         const angle = (i / shapeCount) * Math.PI * 2 * complexity + time * animationSpeed * 0.01
-        const radius = Math.min(width, height) * 0.25
+        const radius = Math.min(width, height) * 0.25 * volumeFactor
         const x = width / 2 + Math.cos(angle) * radius
         const y = height / 2 + Math.sin(angle) * radius
 
@@ -106,9 +117,9 @@ export default function AlgorithmicArtGenerator() {
         ctx.translate(x, y)
         ctx.rotate(angle + time * rotationSpeed * 0.01)
         ctx.globalAlpha = opacity
-        ctx.fillStyle = colors[i % colors.length]
+        ctx.fillStyle = colors[(i + colorOffset) % colors.length]
 
-        const size = shapeSize * (0.5 + Math.sin(time * 0.01 + i) * 0.5)
+        const size = shapeSize * (0.5 + Math.sin(time * 0.01 + i) * 0.5) * volumeFactor
         ctx.beginPath()
         ctx.moveTo(0, -size)
         ctx.lineTo(-size * 0.866, size * 0.5)
@@ -118,20 +129,23 @@ export default function AlgorithmicArtGenerator() {
         ctx.restore()
       }
     },
-    [parameters],
+    [parameters, audioData],
   )
 
   const drawLinePattern = useCallback(
     (ctx: CanvasRenderingContext2D, time: number) => {
+      const { volume, frequency } = audioData
       const { shapeCount, shapeSize, animationSpeed, rotationSpeed, opacity, complexity } = parameters
       const colors = colorPalettes[parameters.colorPalette as PaletteKey]
+      const volumeFactor = 1 + volume
+      const colorOffset = Math.floor(frequency * colors.length)
       const { width, height } = ctx.canvas
 
       ctx.lineWidth = 3
       for (let i = 0; i < shapeCount; i++) {
         const angle = (i / shapeCount) * Math.PI * 2 * complexity + time * animationSpeed * 0.01
-        const startRadius = 50
-        const endRadius = Math.min(width, height) * 0.4
+        const startRadius = 50 * volumeFactor
+        const endRadius = Math.min(width, height) * 0.4 * volumeFactor
 
         const startX = width / 2 + Math.cos(angle) * startRadius
         const startY = height / 2 + Math.sin(angle) * startRadius
@@ -139,36 +153,39 @@ export default function AlgorithmicArtGenerator() {
         const endY = height / 2 + Math.sin(angle + time * rotationSpeed * 0.005) * endRadius
 
         ctx.globalAlpha = opacity
-        ctx.strokeStyle = colors[i % colors.length]
+        ctx.strokeStyle = colors[(i + colorOffset) % colors.length]
         ctx.beginPath()
         ctx.moveTo(startX, startY)
         ctx.lineTo(endX, endY)
         ctx.stroke()
       }
     },
-    [parameters],
+    [parameters, audioData],
   )
 
   const drawSpiral = useCallback(
     (ctx: CanvasRenderingContext2D, time: number) => {
+      const { volume, frequency } = audioData
       const { shapeCount, shapeSize, animationSpeed, rotationSpeed, opacity, complexity } = parameters
       const colors = colorPalettes[parameters.colorPalette as PaletteKey]
+      const volumeFactor = 1 + volume
+      const colorOffset = Math.floor(frequency * colors.length)
       const { width, height } = ctx.canvas
 
       for (let i = 0; i < shapeCount; i++) {
         const t = (i / shapeCount) * complexity * Math.PI * 2 + time * animationSpeed * 0.01
-        const radius = (i / shapeCount) * Math.min(width, height) * 0.4
+        const radius = (i / shapeCount) * Math.min(width, height) * 0.4 * volumeFactor
         const x = width / 2 + Math.cos(t + time * rotationSpeed * 0.005) * radius
         const y = height / 2 + Math.sin(t + time * rotationSpeed * 0.005) * radius
 
         ctx.globalAlpha = opacity
-        ctx.fillStyle = colors[i % colors.length]
+        ctx.fillStyle = colors[(i + colorOffset) % colors.length]
         ctx.beginPath()
-        ctx.arc(x, y, shapeSize * (0.3 + Math.sin(time * 0.01 + i) * 0.2), 0, Math.PI * 2)
+        ctx.arc(x, y, shapeSize * (0.3 + Math.sin(time * 0.01 + i) * 0.2) * volumeFactor, 0, Math.PI * 2)
         ctx.fill()
       }
     },
-    [parameters],
+    [parameters, audioData],
   )
 
   /* ---------- Fractal Drawing Functions ---------- */
@@ -662,6 +679,7 @@ export default function AlgorithmicArtGenerator() {
       opacity: Number((Math.random() * 0.5 + 0.3).toFixed(2)),
       complexity: Math.floor(Math.random() * 5) + 1,
       isAnimated: Math.random() > 0.3,
+      audioReactive: false,
       fractalType: fractalTypes[Math.floor(Math.random() * fractalTypes.length)],
       fractalIterations: Math.floor(Math.random() * 200) + 50,
       fractalScale: Number((Math.random() * 0.8 + 0.2).toFixed(2)),
@@ -869,6 +887,17 @@ export default function AlgorithmicArtGenerator() {
                   />
                   <Label htmlFor="animation" className="text-slate-300">
                     Enable Animation
+                  </Label>
+                </div>
+
+                <div className="flex items-center space-x-2">
+                  <Switch
+                    id="audioReactive"
+                    checked={parameters.audioReactive}
+                    onCheckedChange={(c) => updateParameter("audioReactive", c)}
+                  />
+                  <Label htmlFor="audioReactive" className="text-slate-300">
+                    Audio Reactive
                   </Label>
                 </div>
 

--- a/hooks/use-audio-input.ts
+++ b/hooks/use-audio-input.ts
@@ -1,0 +1,63 @@
+"use client"
+
+import { useState, useEffect } from "react"
+
+export interface AudioData {
+  volume: number
+  frequency: number
+}
+
+export default function useAudioInput(enabled: boolean): AudioData {
+  const [data, setData] = useState<AudioData>({ volume: 0, frequency: 0 })
+
+  useEffect(() => {
+    if (!enabled) {
+      setData({ volume: 0, frequency: 0 })
+      return
+    }
+
+    const AudioCtx =
+      (window as any).AudioContext || (window as any).webkitAudioContext
+    let context: AudioContext
+    let analyser: AnalyserNode
+    let source: MediaStreamAudioSourceNode | undefined
+    let rafId: number
+    const dataArray: Uint8Array = new Uint8Array(256)
+
+    navigator.mediaDevices
+      .getUserMedia({ audio: true })
+      .then((stream) => {
+        context = new AudioCtx()
+        analyser = context.createAnalyser()
+        analyser.fftSize = dataArray.length * 2
+        source = context.createMediaStreamSource(stream)
+        source.connect(analyser)
+
+        const tick = () => {
+          analyser.getByteFrequencyData(dataArray)
+          const avg = dataArray.reduce((a, b) => a + b, 0) / dataArray.length
+          const volume = avg / 255
+          let maxIndex = 0
+          for (let i = 1; i < dataArray.length; i++) {
+            if (dataArray[i] > dataArray[maxIndex]) maxIndex = i
+          }
+          const frequency = maxIndex / dataArray.length
+          setData({ volume, frequency })
+          rafId = requestAnimationFrame(tick)
+        }
+        tick()
+      })
+      .catch((err) => {
+        console.error("Audio input error", err)
+      })
+
+    return () => {
+      if (rafId) cancelAnimationFrame(rafId)
+      if (source) source.disconnect()
+      if (context) context.close()
+    }
+  }, [enabled])
+
+  return data
+}
+


### PR DESCRIPTION
## Summary
- add `useAudioInput` hook for microphone data
- use audio volume/frequency in draw functions
- add `audioReactive` option to art parameters and UI

## Testing
- `npm run lint` *(fails: interactive Next.js ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_b_687c618e7d088333b9c361c18eeefa67