### PR TITLE
Add gallery with local storage

### DIFF
--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { getItems, removeItem, GalleryItem } from "@/lib/gallery"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+export default function GalleryPage() {
+  const [items, setItems] = useState<GalleryItem[]>([])
+
+  useEffect(() => {
+    setItems(getItems())
+  }, [])
+
+  const handleDelete = (id: string) => {
+    removeItem(id)
+    setItems(getItems())
+  }
+
+  const handleDownload = (item: GalleryItem) => {
+    const link = document.createElement("a")
+    link.href = item.dataURL
+    link.download = `algorithmic-art-${item.id}.${item.type}`
+    link.click()
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 to-slate-800 p-4">
+      <div className="max-w-7xl mx-auto space-y-6">
+        <header className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-white mb-2">Gallery</h1>
+          <p className="text-slate-300">Your saved artworks</p>
+          <Link href="/" className="text-blue-400 underline">
+            &larr; Back to generator
+          </Link>
+        </header>
+        {items.length === 0 ? (
+          <p className="text-center text-slate-300">No items saved yet.</p>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+            {items.map((item) => (
+              <Card key={item.id} className="bg-slate-800 border-slate-700">
+                <CardHeader className="p-2 pb-0">
+                  <CardTitle className="text-base text-white">{new Date(item.timestamp).toLocaleString()}</CardTitle>
+                </CardHeader>
+                <CardContent className="p-2 space-y-2">
+                  <img src={item.dataURL} alt="art" className="rounded" />
+                  <div className="flex justify-between">
+                    <Button size="sm" onClick={() => handleDownload(item)} className="bg-blue-600 hover:bg-blue-700 text-white">
+                      Download
+                    </Button>
+                    <Button size="sm" variant="destructive" onClick={() => handleDelete(item.id)}>
+                      Delete
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useRef, useEffect, useCallback } from "react"
+import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Slider } from "@/components/ui/slider"
@@ -9,6 +10,7 @@ import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
 import { Download, Shuffle, Play, Pause, Film, Loader2 } from "lucide-react"
 import { useGifJs } from "@/components/gif-recorder"
+import { addItem, GalleryItem } from "@/lib/gallery"
 
 /* ---------- Types & Constants ---------- */
 
@@ -676,8 +678,17 @@ export default function AlgorithmicArtGenerator() {
 
     const link = document.createElement("a")
     link.download = `algorithmic-art-${Date.now()}.png`
-    link.href = canvas.toDataURL()
+    const data = canvas.toDataURL()
+    link.href = data
     link.click()
+    const item: GalleryItem = {
+      id: Date.now().toString(),
+      type: 'png',
+      dataURL: data,
+      parameters,
+      timestamp: Date.now(),
+    }
+    addItem(item)
   }
 
   /* ---------- GIF Recording ---------- */
@@ -715,8 +726,20 @@ export default function AlgorithmicArtGenerator() {
       link.href = url
       link.download = `algorithmic-art-${Date.now()}.gif`
       link.click()
-      URL.revokeObjectURL(url)
-      setRecording(false)
+      const reader = new FileReader()
+      reader.onload = () => {
+        const item: GalleryItem = {
+          id: Date.now().toString(),
+          type: 'gif',
+          dataURL: reader.result as string,
+          parameters,
+          timestamp: Date.now(),
+        }
+        addItem(item)
+        URL.revokeObjectURL(url)
+        setRecording(false)
+      }
+      reader.readAsDataURL(blob)
     })
 
     gif.render()
@@ -730,6 +753,9 @@ export default function AlgorithmicArtGenerator() {
         <header className="text-center mb-8">
           <h1 className="text-4xl font-bold text-white mb-2">Algorithmic Art Generator</h1>
           <p className="text-slate-300">Create beautiful generative art with customizable parameters</p>
+          <Link href="/gallery" className="text-blue-400 underline">
+            View Gallery
+          </Link>
         </header>
 
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">

--- a/lib/gallery.ts
+++ b/lib/gallery.ts
@@ -1,0 +1,39 @@
+export interface GalleryItem {
+  id: string
+  type: 'png' | 'gif'
+  dataURL: string
+  parameters: any
+  timestamp: number
+}
+
+const KEY = 'aag-gallery'
+
+function load(): GalleryItem[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(KEY)
+    return raw ? (JSON.parse(raw) as GalleryItem[]) : []
+  } catch {
+    return []
+  }
+}
+
+function save(items: GalleryItem[]) {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(KEY, JSON.stringify(items))
+}
+
+export function addItem(item: GalleryItem) {
+  const items = load()
+  items.unshift(item)
+  save(items)
+}
+
+export function getItems(): GalleryItem[] {
+  return load()
+}
+
+export function removeItem(id: string) {
+  const items = load().filter((i) => i.id !== id)
+  save(items)
+}


### PR DESCRIPTION
## Summary
- store downloaded art in localStorage
- add gallery utilities
- create `/gallery` page to view saved items
- link to gallery from home page

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687c6193a2bc8333bbd055d4e4dbb708